### PR TITLE
Fixing default parameter for linting all files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   python-root-list:
     description: "A list of all paths to test"
     required: false
-    default: "'./**/*.py'"
+    default: "."
   use-pylint:
     description: "Use Pylint"
     required: false


### PR DESCRIPTION
Running on Ubuntu, recursive wildcard `**` in `./**/*.py` didn't work, so only files in `./*/*.py` were linted

rahul-deepsource apparently changed it without explaining, in here: https://github.com/rahul-deepsource/pyaction/commit/e3b43b1d9e0375a47832a23ef26db7765def80db#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R7
