### PR TITLE
Added an example actions.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ steps:
       python-version: "3.7"
 ```
 
+### Examples
+* [Only lint changed files, and ignore missing docstrings](examples/actions-only_changed_files.yml)
+
 ## Details
 
 Uses `actions/setup-python@v2`. Only python `3.6` - `3.10` version are tested since

--- a/examples/actions-only_changed_files.yml
+++ b/examples/actions-only_changed_files.yml
@@ -1,0 +1,26 @@
+name: Lint only files changed in Pull Request, and ignore Missing docstrings
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, edited ]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # This is necessary to get the commits
+      - name: Set up Python environment
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+      - name: Get changed python files between base and head
+        run: >
+          echo "CHANGED_FILES=$(echo $(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- | grep \.py))" >> $GITHUB_ENV
+      - if: ${{ env.CHANGED_FILES }}
+        uses: marian-code/python-lint-annotate@v3
+        with:
+          python-root-list: ${{ env.CHANGED_FILES }}
+          extra-pylint-options: "--disable=C0114,C0116"  # Missing doctrings
+          extra-pydocstyle-options: "--ignore=D1"  # Missing doctrings http://www.pydocstyle.org/en/stable/error_codes.html#grouping


### PR DESCRIPTION
An example of an actions.yml file for only linting changed files

It's not perfect, because `git diff` not only includes "changed files" but *all* differences between base and head, which includes files changed by other merged pull requests.