### PR TITLE
Fix mypy's missing stubs error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,7 +118,11 @@ if [ "$6" = true ] ; then
 
     echo Running: mypy --install-types --non-interactive --ignore-missing-imports --follow-imports=silent --show-column-numbers ${14} $1
 
-    mypy --install-types --non-interactive --ignore-missing-imports --follow-imports=silent --show-column-numbers ${14} $1
+    mypy \
+      --install-types --non-interactive \
+      --ignore-missing-imports \
+      --follow-imports=silent \
+      --show-column-numbers ${14} $1
     exit_code=$?
 
     if [ "$exit_code" = "0" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -116,9 +116,9 @@ fi
 
 if [ "$6" = true ] ; then
 
-    echo Running: mypy --ignore-missing-imports --follow-imports=silent --show-column-numbers ${14} $1
+    echo Running: mypy --install-types --non-interactive --ignore-missing-imports --follow-imports=silent --show-column-numbers ${14} $1
 
-    mypy --ignore-missing-imports --follow-imports=silent --show-column-numbers ${14} $1
+    mypy --install-types --non-interactive --ignore-missing-imports --follow-imports=silent --show-column-numbers ${14} $1
     exit_code=$?
 
     if [ "$exit_code" = "0" ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==21.11b1
 flake8==4.0.1
 isort==5.10.1
-mypy==0.910
+mypy~=0.961
 pycodestyle==2.8.0
 pydocstyle==6.1.1
 pylint==2.12.1


### PR DESCRIPTION
I was getting `error: Library stubs not installed for "pymysql" (or incompatible with Python 3.8)` from mypy
Even though the command ran with `--ignore-missing-imports` and `--follow-imports=silent`

I applied the fix from their doc:
https://mypy.readthedocs.io/en/stable/running_mypy.html#library-stubs-not-installed

It fixed my problem.

I also updated mypy to latest version and above (`~=`)