### PR TITLE
Remove Python 3.6 from tests to fix tests

### DIFF
--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v1
     - uses: marian-code/python-lint-annotate@master

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ steps:
 
 ## Details
 
-Uses `actions/setup-python@v2`. Only python `3.6` - `3.10` version are tested since
+Uses `actions/setup-python@v2`. Only python `3.7` - `3.10` version are tested since
 they are by far most common now. Other python `3.x` versions should also work.
 Any python `2.x` versions are unsupported! You can lint on Linux, Windows and MacOS.
 


### PR DESCRIPTION
Python 3.6 is not available on ubuntu-latest (22.04), so the job fails when it cannot find Python 3.6. Python 3.6 was available when ubuntu-latest was 20.04, which is why the test used to work.

Alternatively, you could explicitly set ubuntu-20.04 and/or ubuntu-22.04 in the OS matrix. If you wanted both, you'd have to do some checking to ensure you're not invoking an invalid combination such as ubuntu-22.04 and Python 3.6.