### PR TITLE
Update first-party GitHub Actions

### DIFF
--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: marian-code/python-lint-annotate@master
       with:
         python-root-list: "./tests/*.py ./tests/subtest/*.py"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Basic:
 
 ```yml
 steps:
-  - uses: actions/checkout@v1
+  - uses: actions/checkout@v4
   - uses: marian-code/python-lint-annotate@v3
 ```
 
@@ -38,7 +38,7 @@ Options:
 
 ```yml
 steps:
-  - uses: actions/checkout@v1
+  - uses: actions/checkout@v4
   - uses: marian-code/python-lint-annotate@v3
     with:
       python-root-list: "src/ tests/*"  # accepts wildcards
@@ -54,7 +54,7 @@ steps:
 
 ## Details
 
-Uses `actions/setup-python@v2`. Only python `3.7` - `3.10` version are tested since
+Uses `actions/setup-python@v5`. Only python `3.7` - `3.10` version are tested since
 they are by far most common now. Other python `3.x` versions should also work.
 Any python `2.x` versions are unsupported! You can lint on Linux, Windows and MacOS.
 
@@ -73,9 +73,9 @@ isort==5.10.1
 
 ## IMPORTANT - test environment
 
-The python version is set by `actions/setup-python@v2` using composite actions. This
+The python version is set by `actions/setup-python@v5` using composite actions. This
 means that the the action will change python you might have previously set with
-`actions/setup-python@v2`. There are two ways to circumvent this.
+`actions/setup-python@v5`. There are two ways to circumvent this.
 
 - Keep the lintnig action separated from others
 - Use it at the and of your workflow when the change in python version will not
@@ -93,8 +93,8 @@ jobs:
     name: Lint Python
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - run: |

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
         architecture: x64

--- a/examples/actions-only_changed_files.yml
+++ b/examples/actions-only_changed_files.yml
@@ -8,11 +8,11 @@ jobs:
     name: Lint
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # This is necessary to get the commits
       - name: Set up Python environment
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
       - name: Get changed python files between base and head


### PR DESCRIPTION
Update first-party GitHub Actions to avoid warnings about node12 and node16.
 * Update actions/checkout from v1 to v4
 * Update actions/setup-python from v2/v3 to v5

![image](https://github.com/marian-code/python-lint-annotate/assets/624931/98c053b8-8352-4612-9184-4f8f7a389190)

https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Might conflict with #7. I can do merge conflict resolution as needed.