### PR TITLE
Drop Python 3.7 and support only Python 3.8+

### DIFF
--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v1
     - uses: marian-code/python-lint-annotate@master

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ steps:
       use-mypy: false
       use-vulture: true
       extra-pylint-options: "--output-format="colorized"
-      python-version: "3.7"
+      python-version: "3.8"
 ```
 
 ### Examples
@@ -54,7 +54,7 @@ steps:
 
 ## Details
 
-Uses `actions/setup-python@v2`. Only python `3.7` - `3.10` version are tested since
+Uses `actions/setup-python@v2`. Only python `3.8` - `3.10` version are tested since
 they are by far most common now. Other python `3.x` versions should also work.
 Any python `2.x` versions are unsupported! You can lint on Linux, Windows and MacOS.
 
@@ -112,9 +112,9 @@ jobs:
         use-pylint: false
         use-flake8: false
         use-vulture: true
-        python-version: "3.7"
+        python-version: "3.8"
     - run: |
-        python --version  # this will output 3.7 now !!!
+        python --version  # this will output 3.8 now !!!
 ```
 
 ## License


### PR DESCRIPTION
Python 3.7 is EOL, and updated versions of some dependencies, such as pylint 3, only support Python 3.8+. Drop Python 3.7 in preparation to update those dependencies, which in turn should enable support for Python 3.11 and 3.12.

This is a follow-up to discussion on #7. This by itself doesn't fix anything, just paves the way for further updates.