### PR TITLE
Update pylint from 2.12.1 to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The lintner versions are:
 ```bash
 pycodestyle==2.8.0
 pydocstyle==6.1.1
-pylint==2.12.1
+pylint==3.1.0
 mypy==0.910
 black==21.11b1
 flake8==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ isort==5.10.1
 mypy~=0.961
 pycodestyle==2.8.0
 pydocstyle==6.1.1
-pylint==2.12.1
+pylint==3.1.0
 vulture==2.3


### PR DESCRIPTION
When trying to add Python 3.11 and 3.12, tests failed due to a dependency chain issue with the chain starting at pylint and ending at an outdated version of wrapt that did not support Python 3.11+. The earliest version of pylint with an updated version of wrapt is pylint 2.15. However, pylint 3.1.0 is the current version, so use that instead.

This PR requires #9 because pylint 3 only supports Python 3.8+, but otherwise pylint 3.1.0 installed and the tests ran fine on my fork.