### PR TITLE
Add Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - uses: marian-code/python-lint-annotate@master

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ steps:
 
 ## Details
 
-
-Uses `actions/setup-python@v5`. Only python `3.8` - `3.10` versions prior to `3.8`
-are not tested since they are EOL now.
+Uses `actions/setup-python@v5`. Only python `3.8` - `3.12` versions are tested.
+Python `3.x` versions prior to `3.8` are not tested since they are EOL now.
 Any python `2.x` versions are unsupported! You can lint on Linux, Windows and MacOS.
 
 The lintner versions are:


### PR DESCRIPTION
Finally, add Python 3.11 and 3.12 to the testing matrix and documentation, as discussed in #7.

Also touch up the language in the README about Python versions.

Python 3.11 and 3.12 tests will fail until #10 is merged.
