### PR TITLE
Update all requirements to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,7 @@ Uses `actions/setup-python@v5`. Only python `3.8` - `3.12` versions are tested.
 Python `3.x` versions prior to `3.8` are not tested since they are EOL now.
 Any python `2.x` versions are unsupported! You can lint on Linux, Windows and MacOS.
 
-The lintner versions are:
-
-```bash
-pycodestyle==2.8.0
-pydocstyle==6.1.1
-pylint==3.1.0
-mypy==0.910
-black==21.11b1
-flake8==4.0.1
-vulture==2.3
-isort==5.10.1
-```
+The linter versions are defined in [requirements.txt](requirements.txt).
 
 ## IMPORTANT - test environment
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-black==21.11b1
-flake8==4.0.1
-isort==5.10.1
-mypy~=0.961
-pycodestyle==2.8.0
-pydocstyle==6.1.1
+black==24.3.0
+flake8==7.0.0
+isort==5.13.2
+mypy~=1.9.0
+pycodestyle==2.11.1
+pydocstyle==6.3.0
 pylint==3.1.0
-vulture==2.3
+vulture==2.11


### PR DESCRIPTION
Update all requirements to latest stable versions.

Also, update the README to just point to requirements.txt instead of having to update it every time.

I ran a test run on my fork and the errors were slightly clearer (Black did not error out) or the same (mypy still fails due to no mypy cache directory).

Before: https://github.com/RytoEX/python-lint-annotate/actions/runs/8545019549
After: https://github.com/RytoEX/python-lint-annotate/actions/runs/8545121248