### PR TITLE
Fix: Using different macos versions for python older and newer than 3.11

### DIFF
--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -8,8 +8,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        exclude:
+          - os: macos-latest
+            python-version: 3.8
+          - os: macos-latest
+            python-version: 3.9
+          - os: macos-latest
+            python-version: 3.10
+          - os: macos-13
+            python-version: 3.11
+          - os: macos-13
+            python-version: 3.12
+
     steps:
     - uses: actions/checkout@v4
     - uses: marian-code/python-lint-annotate@master


### PR DESCRIPTION
Closes #17.
 
- Python versions from 3.8 to 3.10 uses macos-13
- Python versions from 3.11 and newer uses macos-latest

<img width="1182" alt="Screenshot 2024-11-16 at 7 15 10 AM" src="https://github.com/user-attachments/assets/610ba9af-157b-4190-835b-5414e5f9bdaf">
