### PR TITLE
Fixes #19 Updating README and adding an example for use-external-python

### DIFF
--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: marian-code/python-lint-annotate@master
+    - uses: ./
       with:
         python-root-list: "./tests/*.py ./tests/subtest/*.py"
         use-black: true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ selected linters.
 - Zero configuration based: Add a single line in your CI and done!
 - GitHub Annotations on PR: Highlights issues inline on the PR diff.
 - Most of the popular community trusted linters in one place.
+- Allows to use either a new or existing Python version using `use-external-python`.
+See [this example](examples/actions-use_external_python.yml).
 
 ## Linters supported
 


### PR DESCRIPTION
- Updating README to mention the new parameter `use-external-python`
- Adding an example, referred in README
- Fixing [.github/workflows/all-lints.yml](https://github.com/marian-code/python-lint-annotate/compare/master...clalarco:python-lint-annotate:issue-19-update-readme?expand=1#diff-497003e4bc6f3b36b18e85751f3e08569844487f09d136bfc77cc2f4f607d938) to use the action from the checked out repository.

Fixes #19 