### PR TITLE
Update macOS runner from macOS 13 to macOS 14

### DIFF
--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         exclude:
           - os: macos-latest


### PR DESCRIPTION
The macOS 13 runner is retired.