### PR TITLE
Fix macOS matrix excludes

### DIFF
--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -17,10 +17,12 @@ jobs:
             python-version: 3.9
           - os: macos-latest
             python-version: 3.10
-          - os: macos-13
-            python-version: 3.11
-          - os: macos-13
-            python-version: 3.12
+          - os: macos-14
+            python-version: 3.8
+          - os: macos-14
+            python-version: 3.9
+          - os: macos-14
+            python-version: 3.10
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fix an oversight from ab76874139ef2ac24c902862cd61075183c1b477 where the matrix was not properly updated to exclude older Python.