### PR TITLE
Fix macOS matrix, update first-party GitHub Actions, fix use-external-python, update all requirements and linters

### DIFF
--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -9,18 +9,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         exclude:
           - os: macos-latest
-            python-version: 3.8
-          - os: macos-latest
-            python-version: 3.9
-          - os: macos-latest
             python-version: 3.10
-          - os: macos-14
-            python-version: 3.8
-          - os: macos-14
-            python-version: 3.9
           - os: macos-14
             python-version: 3.10
 

--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -17,10 +17,12 @@ jobs:
             python-version: 3.9
           - os: macos-latest
             python-version: 3.10
-          - os: macos-13
-            python-version: 3.11
-          - os: macos-13
-            python-version: 3.12
+          - os: macos-14
+            python-version: 3.8
+          - os: macos-14
+            python-version: 3.9
+          - os: macos-14
+            python-version: 3.10
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/all-lints.yml
+++ b/.github/workflows/all-lints.yml
@@ -25,7 +25,7 @@ jobs:
             python-version: 3.10
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ./
       with:
         python-root-list: "./tests/*.py ./tests/subtest/*.py"

--- a/.github/workflows/test-python-install.yml
+++ b/.github/workflows/test-python-install.yml
@@ -14,11 +14,11 @@ jobs:
     env:
       python-test-package: python-dummy
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Python if required
       if: ${{ matrix.use-external-python }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Basic:
 
 ```yml
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
   - uses: marian-code/python-lint-annotate@v4
 ```
 
@@ -40,7 +40,7 @@ Options:
 
 ```yml
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
   - uses: marian-code/python-lint-annotate@v4
     with:
       python-root-list: "src/ tests/*"  # accepts wildcards
@@ -56,7 +56,7 @@ steps:
 
 ## Details
 
-Uses `actions/setup-python@v5`. Only python `3.8` - `3.12` versions are tested.
+Uses `actions/setup-python@v6`. Only python `3.8` - `3.12` versions are tested.
 Python `3.x` versions prior to `3.8` are not tested since they are EOL now.
 Any python `2.x` versions are unsupported! You can lint on Linux, Windows and MacOS.
 
@@ -64,9 +64,9 @@ The linter versions are defined in [requirements.txt](requirements.txt).
 
 ## IMPORTANT - test environment
 
-The python version is set by `actions/setup-python@v5` using composite actions. This
+The python version is set by `actions/setup-python@v6` using composite actions. This
 means that the the action will change python you might have previously set with
-`actions/setup-python@v5`. There are two ways to circumvent this.
+`actions/setup-python@v6`. There are two ways to circumvent this.
 
 - Keep the lintnig action separated from others
 - Use it at the and of your workflow when the change in python version will not
@@ -84,8 +84,8 @@ jobs:
     name: Lint Python
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - run: |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ steps:
       use-mypy: false
       use-vulture: true
       extra-pylint-options: "--output-format="colorized"
-      python-version: "3.8"
+      python-version: "3.10"
 ```
 
 ### Examples
@@ -56,8 +56,8 @@ steps:
 
 ## Details
 
-Uses `actions/setup-python@v6`. Only python `3.8` - `3.12` versions are tested.
-Python `3.x` versions prior to `3.8` are not tested since they are EOL now.
+Uses `actions/setup-python@v6`. Only python `3.10` - `3.14` versions are tested.
+Python `3.x` versions prior to `3.10` are not tested since they are EOL now.
 Any python `2.x` versions are unsupported! You can lint on Linux, Windows and MacOS.
 
 The linter versions are defined in [requirements.txt](requirements.txt).
@@ -87,9 +87,9 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.10
     - run: |
-        python --version  # this will output 3.9 now
+        python --version  # this will output 3.10 now
         run tests or other things using python ...
     - uses: marian-code/python-lint-annotate@v4
       with:
@@ -103,9 +103,9 @@ jobs:
         use-pylint: false
         use-flake8: false
         use-vulture: true
-        python-version: "3.8"
+        python-version: "3.10"
     - run: |
-        python --version  # this will output 3.8 now !!!
+        python --version  # this will output 3.10 now !!!
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
   steps:
     - name: Setup python
       if: ${{ ! inputs.use-external-python }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
         architecture: x64

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ inputs:
   python-version:
     description: "Set desired python version with this keyword"
     required: false
-    default: "3.8"
+    default: "3.10"
   use-external-python:
     description: "false (default): Install a new Python for this action; true: use the python installation in the previous steps"
     type: boolean

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup python
-      if: ${{ ! inputs.use-external-python }}
+      if: ${{ ! fromJSON(inputs.use-external-python) }}
       uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}

--- a/examples/actions-only_changed_files.yml
+++ b/examples/actions-only_changed_files.yml
@@ -19,7 +19,7 @@ jobs:
         run: >
           echo "CHANGED_FILES=$(echo $(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- | grep \.py))" >> $GITHUB_ENV
       - if: ${{ env.CHANGED_FILES }}
-        uses: marian-code/python-lint-annotate@v3
+        uses: marian-code/python-lint-annotate@v4
         with:
           python-root-list: ${{ env.CHANGED_FILES }}
           extra-pylint-options: "--disable=C0114,C0116"  # Missing doctrings

--- a/examples/actions-only_changed_files.yml
+++ b/examples/actions-only_changed_files.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Get changed python files between base and head
         run: >
           echo "CHANGED_FILES=$(echo $(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- | grep \.py))" >> $GITHUB_ENV

--- a/examples/actions-only_changed_files.yml
+++ b/examples/actions-only_changed_files.yml
@@ -8,11 +8,11 @@ jobs:
     name: Lint
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # This is necessary to get the commits
       - name: Set up Python environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.8"
       - name: Get changed python files between base and head

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-black==24.3.0
-flake8==7.0.0
-isort==5.13.2
-mypy~=1.9.0
-pycodestyle==2.11.1
+black==26.1.0
+flake8==7.3.0
+isort==8.0.0
+mypy~=1.19.1
+pycodestyle==2.14.0
 pydocstyle==6.3.0
-pylint==3.1.0
-vulture==2.11
+pylint==4.0.5
+vulture==2.14


### PR DESCRIPTION
This PR can supersede #22 and #23 if desired. This PR:
* Fixes the macOS matrix excludes oversight from #21
* Updates all first-party GitHub Actions to avoid warnings about node20
* Fixes the use-external-python action input
* Updates all Python requirements and linters to the latest stable versions (as of 2026-02-25)
* Updates the example code to use v4 of this action

You can see successful runs on my repo here where the specified Python versions match the logs:
* https://github.com/marian-code/python-lint-annotate/actions/runs/22420506476
* https://github.com/marian-code/python-lint-annotate/actions/runs/22420506488